### PR TITLE
Urxvt transparency is working.

### DIFF
--- a/.Xresources
+++ b/.Xresources
@@ -20,7 +20,6 @@ URxvt*scrollBar_right: false
 URxvt*scrollBar_floating: false
 URxvt.transparent:  false
 ! Urxvt*shading: 20
-! URxvt*background: rgba:0000/0000/0000/cccc
 
 !URxvt.fading: 70
 !URxvt.fadeColor: [0]black
@@ -37,8 +36,8 @@ URxvt*foreground: White
 URxvt*colorUL: yellow
 URxvt*underlineColor: yellow
 urxvt*depth: 32
-URxvt*background: rgba:0000/0000/0200/08cc
-
+URxvt*background: rgba:0000/0000/0300/a222
+! URxvt*background: rgba:0000/0000/0000/cccc
 
 !URxvt*font: -xos4-terminus-medium-*-*-*-18-*-*-*-*-*-iso8859-15,xft:terminus:pixelsize:12
 !URxvt*boldFont: -xos4-terminus-bold-*-*-*-18-*-*-*-*-*-iso8859-15,xft:terminus:bold:pixelsize:12
@@ -64,7 +63,6 @@ URxvt*print-pipe: cat > $HOME/$(echo urxvt.dump.$(date +'%Y%M%d%H%m%S'))
 URxvt*perl-ext:
 
 
-URxvt.background:       #000000
 URxvt.foreground:       gray75
 URxvt.color3:           DarkGoldenrod
 URxvt.color4:           RoyalBlue


### PR DESCRIPTION
transparency in xmonad.hs was smashing the Xresources settings. There was also an errant background setting in Xresources which was preventing it from working as expected.
This fixes it along with the changes to Xmonad.hs.